### PR TITLE
Strip kubectl to use uncached DiscoveryInterface

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -68,7 +68,7 @@ type RESTClientGetter interface {
 	// ToRESTConfig returns restconfig
 	ToRESTConfig() (*rest.Config, error)
 	// ToDiscoveryClient returns discovery client
-	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	ToDiscoveryClient() (discovery.DiscoveryInterface, error)
 	// ToRESTMapper returns a restmapper
 	ToRESTMapper() (meta.RESTMapper, error)
 	// ToRawKubeConfigLoader return kubeconfig loader as-is
@@ -111,7 +111,7 @@ type ConfigFlags struct {
 	restMapper     meta.RESTMapper
 	restMapperLock sync.Mutex
 
-	discoveryClient     discovery.CachedDiscoveryInterface
+	discoveryClient     discovery.DiscoveryInterface
 	discoveryClientLock sync.Mutex
 
 	// If set to true, will use persistent client config, rest mapper, discovery client, and
@@ -245,14 +245,14 @@ func (f *ConfigFlags) toRawKubePersistentConfigLoader() clientcmd.ClientConfig {
 // ToDiscoveryClient implements RESTClientGetter.
 // Expects the AddFlags method to have been called.
 // Returns a CachedDiscoveryInterface using a computed RESTConfig.
-func (f *ConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *ConfigFlags) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	if f.usePersistentConfig {
 		return f.toPersistentDiscoveryClient()
 	}
 	return f.toDiscoveryClient()
 }
 
-func (f *ConfigFlags) toPersistentDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *ConfigFlags) toPersistentDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	f.discoveryClientLock.Lock()
 	defer f.discoveryClientLock.Unlock()
 
@@ -266,7 +266,7 @@ func (f *ConfigFlags) toPersistentDiscoveryClient() (discovery.CachedDiscoveryIn
 	return f.discoveryClient, nil
 }
 
-func (f *ConfigFlags) toDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *ConfigFlags) toDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	config, err := f.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func (f *ConfigFlags) toRESTMapper() (meta.RESTMapper, error) {
 		return nil, err
 	}
 
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	mapper := restmapper.NewDeferredUncachedDiscoveryRESTMapper(discoveryClient)
 	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
 	return expander, nil
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -31,7 +31,7 @@ import (
 // and interfaces that implements RESTClientGetter
 type TestConfigFlags struct {
 	clientConfig    clientcmd.ClientConfig
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 	restMapper      meta.RESTMapper
 }
 
@@ -54,7 +54,7 @@ func (f *TestConfigFlags) ToRESTConfig() (*rest.Config, error) {
 
 // ToDiscoveryClient implements RESTClientGetter.
 // Returns a CachedDiscoveryInterface
-func (f *TestConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *TestConfigFlags) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return f.discoveryClient, nil
 }
 
@@ -65,7 +65,7 @@ func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
 		return f.restMapper, nil
 	}
 	if f.discoveryClient != nil {
-		mapper := restmapper.NewDeferredDiscoveryRESTMapper(f.discoveryClient)
+		mapper := restmapper.NewDeferredUncachedDiscoveryRESTMapper(f.discoveryClient)
 		expander := restmapper.NewShortcutExpander(mapper, f.discoveryClient)
 		return expander, nil
 	}
@@ -85,7 +85,7 @@ func (f *TestConfigFlags) WithRESTMapper(mapper meta.RESTMapper) *TestConfigFlag
 }
 
 // WithDiscoveryClient sets the discoveryClient flag
-func (f *TestConfigFlags) WithDiscoveryClient(c discovery.CachedDiscoveryInterface) *TestConfigFlags {
+func (f *TestConfigFlags) WithDiscoveryClient(c discovery.DiscoveryInterface) *TestConfigFlags {
 	f.discoveryClient = c
 	return f
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -191,7 +191,7 @@ type noopClientGetter struct{}
 func (noopClientGetter) ToRESTConfig() (*rest.Config, error) {
 	return nil, fmt.Errorf("local operation only")
 }
-func (noopClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (noopClientGetter) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return nil, fmt.Errorf("local operation only")
 }
 func (noopClientGetter) ToRESTMapper() (meta.RESTMapper, error) {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/interfaces.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/interfaces.go
@@ -26,7 +26,7 @@ import (
 
 type RESTClientGetter interface {
 	ToRESTConfig() (*rest.Config, error)
-	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	ToDiscoveryClient() (discovery.DiscoveryInterface, error)
 	ToRESTMapper() (meta.RESTMapper, error)
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -63,7 +63,7 @@ type CachedDiscoveryClient struct {
 	openapiClient openapi.Client
 }
 
-var _ discovery.CachedDiscoveryInterface = &CachedDiscoveryClient{}
+var _ discovery.DiscoveryInterface = &CachedDiscoveryClient{}
 
 // ServerResourcesForGroupVersion returns the supported resources for a group and version.
 func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
@@ -282,7 +282,7 @@ func (d *CachedDiscoveryClient) Invalidate() {
 // CachedDiscoveryClient cache data. If httpCacheDir is empty, the restconfig's transport will not
 // be updated with a roundtripper that understands cache responses.
 // If discoveryCacheDir is empty, cached server resource data will be looked up in the current directory.
-func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (*CachedDiscoveryClient, error) {
+func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCacheDir, httpCacheDir string, ttl time.Duration) (discovery.DiscoveryInterface, error) {
 	if len(httpCacheDir) > 0 {
 		// update the given restconfig with a custom roundtripper that
 		// understands how to handle cache responses.
@@ -292,21 +292,5 @@ func NewCachedDiscoveryClientForConfig(config *restclient.Config, discoveryCache
 		})
 	}
 
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return newCachedDiscoveryClient(discoveryClient, discoveryCacheDir, ttl), nil
-}
-
-// NewCachedDiscoveryClient creates a new DiscoveryClient.  cacheDirectory is the directory where discovery docs are held.  It must be unique per host:port combination to work well.
-func newCachedDiscoveryClient(delegate discovery.DiscoveryInterface, cacheDirectory string, ttl time.Duration) *CachedDiscoveryClient {
-	return &CachedDiscoveryClient{
-		delegate:       delegate,
-		cacheDirectory: cacheDirectory,
-		ttl:            ttl,
-		ourFiles:       map[string]struct{}{},
-		fresh:          true,
-	}
+	return discovery.NewDiscoveryClientForConfig(config)
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -19,7 +19,6 @@ package disk
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -39,94 +38,6 @@ import (
 	"k8s.io/client-go/rest/fake"
 	testutil "k8s.io/client-go/util/testing"
 )
-
-func TestCachedDiscoveryClient_Fresh(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 60*time.Second)
-	assert.True(cdc.Fresh(), "should be fresh after creation")
-
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after another groups call")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after resources call")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after another resources call")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
-	cdc.ServerGroups()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
-	assert.Equal(c.groupCalls, 1)
-
-	cdc.ServerGroupsAndResources()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
-	assert.Equal(c.resourceCalls, 1)
-
-	cdc.Invalidate()
-	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
-
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
-	assert.Equal(c.resourceCalls, 2)
-}
-
-func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
-	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 1)
-
-	time.Sleep(1 * time.Second)
-
-	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 2)
-}
-
-func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
-	assert := assert.New(t)
-
-	d, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	os.RemoveAll(d)
-	defer os.RemoveAll(d)
-
-	c := fakeDiscoveryClient{}
-	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
-	cdc.ServerGroups()
-
-	err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			assert.Equal(os.FileMode(0750), info.Mode().Perm())
-		} else {
-			assert.Equal(os.FileMode(0660), info.Mode().Perm())
-		}
-		return nil
-	})
-	assert.NoError(err)
-}
 
 // Tests that schema instances returned by openapi cached and returned after
 // successive calls
@@ -170,7 +81,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 	// should be cached in memory.
 	paths, err := openapiClient.Paths()
 	require.NoError(t, err)
-	assert.Equal(t, 1, fakeServer.RequestCounters["/openapi/v3"])
+	assert.Equal(t, 2, fakeServer.RequestCounters["/openapi/v3"])
 
 	require.Greater(t, len(paths), 0)
 	i := 0
@@ -188,8 +99,6 @@ func TestOpenAPIDiskCache(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
-		client.Invalidate()
-
 		// Refetch the schema from a new openapi client to try to force a new
 		// http request
 		newPaths, err := client.OpenAPIV3().Paths()
@@ -200,7 +109,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 		// Ensure schema call is still served from disk
 		_, err = newPaths[k].Schema()
 		assert.NoError(t, err)
-		assert.Equal(t, 1+i, fakeServer.RequestCounters["/openapi/v3"])
+		assert.Equal(t, 2+i, fakeServer.RequestCounters["/openapi/v3"])
 		assert.Equal(t, 1, fakeServer.RequestCounters[path])
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -145,11 +145,6 @@ func (o *APIResourceOptions) RunAPIResources(cmd *cobra.Command, f cmdutil.Facto
 		return err
 	}
 
-	if !o.Cached {
-		// Always request fresh data from the server
-		discoveryclient.Invalidate()
-	}
-
 	errs := []error{}
 	lists, err := discoveryclient.ServerPreferredResources()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
@@ -38,7 +38,7 @@ var (
 
 // APIVersionsOptions have the data required for API versions
 type APIVersionsOptions struct {
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 
 	genericclioptions.IOStreams
 }
@@ -82,9 +82,6 @@ func (o *APIVersionsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 
 // RunAPIVersions does the work
 func (o *APIVersionsOptions) RunAPIVersions() error {
-	// Always request fresh data from the server
-	o.discoveryClient.Invalidate()
-
 	groupList, err := o.discoveryClient.ServerGroups()
 	if err != nil {
 		return fmt.Errorf("couldn't get available api versions from server: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -368,13 +368,6 @@ type fakeCachedDiscoveryClient struct {
 	discovery.DiscoveryInterface
 }
 
-func (d *fakeCachedDiscoveryClient) Fresh() bool {
-	return true
-}
-
-func (d *fakeCachedDiscoveryClient) Invalidate() {
-}
-
 func (d *fakeCachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return []*metav1.APIGroup{}, []*metav1.APIResourceList{}, nil
 }
@@ -593,7 +586,7 @@ func (f *TestFactory) RESTClient() (*restclient.RESTClient, error) {
 }
 
 // DiscoveryClient returns a discovery client from TestFactory
-func (f *TestFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *TestFactory) DiscoveryClient() (discovery.DiscoveryInterface, error) {
 	fakeClient := f.Client.(*fake.RESTClient)
 
 	cacheDir := filepath.Join("", ".kube", "cache", "discovery")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -66,7 +66,8 @@ func (f *factoryImpl) ToRESTMapper() (meta.RESTMapper, error) {
 	return f.clientGetter.ToRESTMapper()
 }
 
-func (f *factoryImpl) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+// this will return just a DiscoveryInterface
+func (f *factoryImpl) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return f.clientGetter.ToDiscoveryClient()
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/kubectl_match_version.go
@@ -84,7 +84,7 @@ func (f *MatchVersionFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return f.Delegate.ToRawKubeConfigLoader()
 }
 
-func (f *MatchVersionFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+func (f *MatchVersionFlags) ToDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	if err := f.checkMatchingServerVersion(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -57,7 +57,7 @@ type Options struct {
 	Short      bool
 	Output     string
 
-	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryClient discovery.DiscoveryInterface
 
 	genericclioptions.IOStreams
 }
@@ -130,8 +130,6 @@ func (o *Options) Run() error {
 	versionInfo.KustomizeVersion = getKustomizeVersion()
 
 	if !o.ClientOnly && o.discoveryClient != nil {
-		// Always request fresh data from the server
-		o.discoveryClient.Invalidate()
 		versionInfo.ServerVersion, serverErr = o.discoveryClient.ServerVersion()
 	}
 


### PR DESCRIPTION
Stop using the `CachedDiscoveryInterface`in the disk cached discovery client  in favor of just the regular `DiscoveryInterface`, because we will instead be using simple http caching to determine what discovery calls the client should make.